### PR TITLE
username/udn comparison

### DIFF
--- a/www/include/functions.php
+++ b/www/include/functions.php
@@ -343,7 +343,15 @@ function addUserToGroups($uid,$groups) {
   //expects an array of group names
   $con = LDAPconnect();
   $udn=getUserDN($uid);
-  $entry[LDAP_GROUP_ATTR] = $udn;
+
+  # The attributes member and uniqueMember contain the DN
+  if (LDAP_GROUP_ATTR == 'memberuid') {
+    $entry[LDAP_GROUP_ATTR] = $uid;
+  }
+  else {
+    $entry[LDAP_GROUP_ATTR] = $udn;
+  }
+  
   $fail = false;
   foreach ($groups as $group) {
     //the select html tag may send an empty string
@@ -381,7 +389,15 @@ function removeUserFromGroups($uid,$groups) {
   //expects an array of group names
   $con = LDAPconnect();
   $udn=getUserDN($uid);
-  $entry[LDAP_GROUP_ATTR] = $udn;
+
+  # The attributes member and uniqueMember contain the DN
+  if (LDAP_GROUP_ATTR == 'memberuid') {
+    $entry[LDAP_GROUP_ATTR] = $uid;
+  }
+  else {
+    $entry[LDAP_GROUP_ATTR] = $udn;
+  }
+  
   $fail = false;
   foreach ($groups as $group) {
     $result = ldap_mod_del($con[0],"cn=$group,".LDAP_GROUPS_DN,$entry);
@@ -456,12 +472,21 @@ function getUserMembership($uid) {
   $udn=getUserDN($uid);
   $result = ldap_search($con[0],LDAP_GROUPS_DN,"(cn=*)",array('cn',LDAP_GROUP_ATTR));
   $entries = ldap_get_entries($con[0],$result);
-  ldap_close($con[0]);
+  ldap_close($con[0]); 
+
+  # The attributes member and uniqueMember contain the DN
+  if (LDAP_GROUP_ATTR == 'memberuid') {
+    $ident = $uid;
+  }
+  else {
+    $ident = $udn;
+  }
+
   $groups = array();
   for ($i = 0; $i < $entries['count']; $i++) {
     if (isset($entries[$i][LDAP_GROUP_ATTR])) {
       for ($j = 0; $j < $entries[$i][LDAP_GROUP_ATTR]['count']; $j++) {
-        if ($entries[$i][LDAP_GROUP_ATTR][$j] == $udn) {
+        if ($entries[$i][LDAP_GROUP_ATTR][$j] == $ident) {
           $groups[] = $entries[$i]['cn'][0];
           break;
         }

--- a/www/login.php
+++ b/www/login.php
@@ -41,7 +41,7 @@ if ($_POST) {
         ldap_close($con);
         $success = false;
         for ($i = 0; $i < $entries[0][LDAP_GROUP_ATTR]['count']; $i++) {
-          if ($entries[0][LDAP_GROUP_ATTR][$i] == $udn) {
+          if ($entries[0][LDAP_GROUP_ATTR][$i] == $username) {
             $_SESSION['id'] = $username;
             $success = true;
             writeLog('login-access.log',$udn.' '.logged_in);

--- a/www/login.php
+++ b/www/login.php
@@ -36,23 +36,20 @@ if ($_POST) {
       $udn=getUserDN($username);
       $bind = @ldap_bind($con,$udn,$pass);
       if ($bind) {
-        $result = ldap_read($con,LDAP_AUTH_GROUP,"(".LDAP_GROUP_ATTR."=*)",array(LDAP_GROUP_ATTR)); //equivalent to ldap_search()
-        $entries = ldap_get_entries($con,$result);
-        ldap_close($con);
-        $success = false;
-        for ($i = 0; $i < $entries[0][LDAP_GROUP_ATTR]['count']; $i++) {
-          if ($entries[0][LDAP_GROUP_ATTR][$i] == $username) {
+        # Get the groups the user is a member of
+        # and allow access if member of LDAP_GROUP_ATTR
+        $groups = getUserMembership($username);     
+        $ldap_auth_group_cn = explode('=', explode(',', LDAP_AUTH_GROUP)[0])[1];
+        if (in_array($ldap_auth_group_cn, $groups)) {
             $_SESSION['id'] = $username;
-            $success = true;
             writeLog('login-access.log',$udn.' '.logged_in);
             $domain = explode('/', URL)[2];
             $path = explode('/', URL)[3];
             setcookie("sessionPersists", $username, time()+3600*24*30, $path, $domain, 1);
             ob_end_clean(); //cleans the output buffer and stops buffering
             header("Location: index.php");
-          }
         }
-        if (!$success) {
+        else {
           $err[] = unauthorized;
           writeLog('login-error.log',$udn.' '.unauthorized_log);
         }


### PR DESCRIPTION
Hi @dcc6fvo ,

I had to change back to `$username` because, at least in my test environment, the memberships for `LDAP_AUTH_GROUP` seem to work comparing the bare uids and not their distinguished names. We can maybe instruct the PHP LDAP module to use the distinguished names instead so the comparison works as it was intended? Just proposing a workaround, at the moment.

I presume that you might be bypassing the `LDAP_AUTH_GROUP` limitation during development. That is completely fine, I just wanted to let you know.

Keep up that good work, just started going through it!
